### PR TITLE
chore: update warp-terminal-preview to 0.2025.10.01.08.12.preview.02

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,11 @@
     packages = forAll (pkgs:
       let
         debUrl = "https://app.warp.dev/download?channel=preview&package=deb";
-        debSha = "sha256-6/MvbgLuSkLLfS+ud0Av5fkeV7khbtJ9pmErIFduJvs=";
+        debSha = "sha256-zRJOGuq2U//2VENhLhZGVO6zyk4rsGmEQJ219AeihwE=";
       in {
         default = pkgs.stdenv.mkDerivation {
           pname   = "warp-terminal-preview";
-          version = "0.2025.09.24.08.13.preview.03";
+          version = "0.2025.10.01.08.12.preview.02";
 
           src = pkgs.fetchurl {
             url = debUrl;


### PR DESCRIPTION
## Automated Update

This PR updates the warp-terminal-preview package:

- **Version**: 0.2025.10.01.08.12.preview.02
- **SHA256**: sha256-zRJOGuq2U//2VENhLhZGVO6zyk4rsGmEQJ219AeihwE=
- **Flake inputs**: Updated to latest nixpkgs

The package has been built and verified successfully.