### PR TITLE
chore: update warp-terminal-preview to 0.2025.10.07.18.16.preview.00

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,11 @@
     packages = forAll (pkgs:
       let
         debUrl = "https://app.warp.dev/download?channel=preview&package=deb";
-        debSha = "sha256-zRJOGuq2U//2VENhLhZGVO6zyk4rsGmEQJ219AeihwE=";
+        debSha = "sha256-/sZoX6AJ7RfggWRKSrWNp9VCEyikSMIZUTlLG6v5MYM=";
       in {
         default = pkgs.stdenv.mkDerivation {
           pname   = "warp-terminal-preview";
-          version = "0.2025.10.01.08.12.preview.02";
+          version = "0.2025.10.07.18.16.preview.00";
 
           src = pkgs.fetchurl {
             url = debUrl;


### PR DESCRIPTION
## Automated Update

This PR updates the warp-terminal-preview package:

- **Version**: 0.2025.10.07.18.16.preview.00
- **SHA256**: sha256-/sZoX6AJ7RfggWRKSrWNp9VCEyikSMIZUTlLG6v5MYM=
- **Flake inputs**: Updated to latest nixpkgs

The package has been built and verified successfully.