### PR TITLE
chore: bump CI actions and fix xorg deprecation warnings

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v5
+
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.dpkg pkgs.makeWrapper pkgs.file ];
           buildInputs = with pkgs; [
             stdenv.cc.cc zlib libGL curl alsa-lib
-            xorg.libX11 xorg.libXext xorg.libXcursor xorg.libXi xorg.libXrandr xorg.libxcb
+            libx11 libxext libxcursor libxi libxrandr libxcb
             libxkbcommon wayland gtk3 pango cairo fontconfig freetype libdrm
           ];
 
@@ -45,8 +45,8 @@
               --prefix PATH : /run/wrappers/bin \
               --prefix XDG_DATA_DIRS : "$out/share" \
               --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath [
-                pkgs.libGL pkgs.libxkbcommon pkgs.wayland pkgs.xorg.libX11
-                pkgs.xorg.libXcursor pkgs.xorg.libXi pkgs.xorg.libXrandr
+                pkgs.libGL pkgs.libxkbcommon pkgs.wayland pkgs.libx11
+                pkgs.libxcursor pkgs.libxi pkgs.libxrandr
                 pkgs.fontconfig pkgs.freetype
               ]}
 


### PR DESCRIPTION
## Summary

Address warnings from the latest workflow run ([25071301852](https://github.com/jordangarrison/warp-preview-flake/actions/runs/25071301852)):

- **Node 20 deprecation**: bump `actions/checkout` v4 → v5 and `cachix/install-nix-action` v24 → v31. GitHub will force Node 24 starting 2026-06-02 and remove Node 20 on 2026-09-16.
- **xorg deprecation**: nixpkgs deprecated the `xorg` package set. Renamed `xorg.libX11`/`libXext`/`libXcursor`/`libXi`/`libXrandr`/`libxcb` → top-level `libx11`/`libxext`/`libxcursor`/`libxi`/`libxrandr`/`libxcb` in `buildInputs` and `LD_LIBRARY_PATH`.

## Test plan

- [x] `nix build .#default --system x86_64-linux` succeeds locally with no eval warnings
- [ ] Workflow run on this branch completes without deprecation warnings (verify on next scheduled run or manual dispatch)